### PR TITLE
Changed codeblock and spelling

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,18 +10,17 @@ So how do we start?
 --GETTING STARTED--
 
 To work with everything on your own computer and be able to test it, as mentioned, you need to set up XAMPP or equivalents - and also get Git for your computer. Otherwise, you can just write code online. I'm just learning GitHub, but I suspect you won't be able to run the code if you do that.
-You will have to create a new Database - lets call it "OurGitHubForum" - in mysql (e.g. via browser -> http://localhost/phpmyadmin). If you don't know how to do that, contact me or research it on the internet. Second, after you downloaded the code from GitHub, open the folder "database" and make a new file called "connect_data.php". Put the following code in it (ignore the comment marks "<!--" and "-->":
+You will have to create a new Database - lets call it "OurGitHubForum" - in mysql (e.g. via browser -> http://localhost/phpmyadmin). If you don't know how to do that, contact me or research it on the internet. Second, after you downloaded the code from GitHub, open the folder "database" and make a new file called "connect_data.php". Put the following code in it:
 
-<!-- 
-<?PHP
+```<?PHP
 $servername = "[put in your servername, usually: localhost]";
 $username = "[put in your username for phpmyadmin]";
 $password = "[put in your password for phpmyadmin]";
 $database = "[put in the database name, e.g.: OurGitHubForum]";
 ?>
--->
+```
 
-Now just call the database/mysql_setup.php file using your browser - just once - and check in phpmyadmin to make sure that the tables were created correctl. If not, make sure that you put in the correct data in the file you created and otherwise comment the bug here in GitHub. Every time you download a new version of the code that changes the tables, run the file mysql_setup.php again. It will delete the old tables and create the updated tables.
+Now just call the database/mysql_setup.php file using your browser - just once - and check in phpmyadmin to make sure that the tables were created correctly. If not, make sure that you put in the correct data in the file you created and otherwise comment the bug here in GitHub. Every time you download a new version of the code that changes the tables, run the file mysql_setup.php again. It will delete the old tables and create the updated tables.
 
 --STRUCTURE--
 


### PR DESCRIPTION
The code for connect_data.php was not visible when viewing README.md. This should fix it, by displaying it as a codeblock (https://github.com/adam-p/markdown-here/wiki/Markdown-Cheatsheet#code). 

On line 23, there was a typo and I fixed it.